### PR TITLE
[FIX] - slugify

### DIFF
--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -115,13 +115,6 @@ export function SlugDecorator<T>(
         target,
         key
     );
-
-    Object.defineProperty(target, key, {
-        enumerable: true,
-        get() {
-            return slugify(seed(this), config.options);
-        }
-    });
 }
 
 export function Slugify<T = any>(config: ISlugifyOptions<T>) {

--- a/src/test/decorators.spec.ts
+++ b/src/test/decorators.spec.ts
@@ -11,10 +11,4 @@ describe('Slug decorator', () => {
         expect(target.slug).toEqual('john-smith');
         expect(target.slug2).toEqual('john-smith');
     });
-
-    test('should handle options.generate and options.keys on new class call', () => {
-        const target = new EntitySlugTest('John', 'Smith');
-        expect(target.slug).toEqual('john-smith');
-        expect(target.slug2).toEqual('john-smith');
-    });
 });

--- a/src/test/module/entity.slug.ts
+++ b/src/test/module/entity.slug.ts
@@ -3,11 +3,6 @@ import { Type } from 'class-transformer';
 import { Slugify } from '../../decorators';
 
 export class EntitySlugTest {
-    constructor(firstName: string, lastName: string) {
-        this.firstName = firstName;
-        this.lastName = lastName;
-    }
-
     @Type(() => String)
     public readonly firstName: string;
 


### PR DESCRIPTION
my bad - on peut pas utiliser à la fois un transform et un custom getter sur la property.
Du coup, le slugify va permettre d'hydrater le slug lors d'un transform si il est null/undefined (plainToClass ou ClassToPlain) -> c'est notre use-case principal.

Par contre, le slug restera empty sans transform : 

```javascript
class Sluggable { /* ... */ }
const foo = new Sluggable();
foo.slug /* undefined */
```

est-ce que ça vaut le coup de rajouter une méthode directement sur la class via le decorator ?
```javascript
/* pour pouvoir faire : */
foo.generateSlug();
foo.slug /* slug-of-doom */
```

