### PR TITLE
[FEAT] - Mongo ClientSessions via cls-hooked

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,12 +1,16 @@
 export const DEBUG = 'nestjs-mongo';
+
 export const DEFAULT_CONNECTION_NAME = 'nestjs-mongo:connection:default';
 export const NAMED_CONNECTION_TOKEN = 'nestjs-mongo:connection:name';
+
 export const RELATIONSHIP_METADATA_NAME = 'nestjs-mongo:relationship';
 export const INVERSED_RELATIONSHIP_METADATA_NAME =
     'nestjs-mongo:inversed_relationship';
-export const LOADER_SESSION_NAME = 'nestjs-mongo:loaders_session';
-export const MONGO_SESSION_KEY = 'nestjs-mongo:loader_mongosession';
 export const RELATIONSHIPS_CASCADES_METADATA_NAME =
     'nestjs-mongo:relationships_cascades';
 export const CHILD_RELATIONSHIPS = 'nestjs-mongo:child_relationships';
 export const INDEX_METADATA_NAME = 'nestjs-mongo:index';
+
+export const DATA_LOADER_NAMESPACE = 'nestjs-mongo:ns_dataloader';
+export const SESSION_LOADER_NAMESPACE = 'nestjs-mongo:ns_sessionloader';
+export const MONGO_SESSION_KEY = 'ns_sessionloader:mongo_client_session';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,7 @@ export const RELATIONSHIP_METADATA_NAME = 'nestjs-mongo:relationship';
 export const INVERSED_RELATIONSHIP_METADATA_NAME =
     'nestjs-mongo:inversed_relationship';
 export const LOADER_SESSION_NAME = 'nestjs-mongo:loaders_session';
+export const MONGO_SESSION_KEY = 'nestjs-mongo:loader_mongosession';
 export const RELATIONSHIPS_CASCADES_METADATA_NAME =
     'nestjs-mongo:relationships_cascades';
 export const CHILD_RELATIONSHIPS = 'nestjs-mongo:child_relationships';

--- a/src/dataloader/middleware.ts
+++ b/src/dataloader/middleware.ts
@@ -10,7 +10,7 @@ import { MongoManager } from '../manager';
 import { DataloaderService } from './service';
 
 @Injectable()
-export class DataLooaderMiddleware implements NestMiddleware {
+export class DataLoaderMiddleware implements NestMiddleware {
     protected log = Debug(DEBUG + ':DataLooaderMiddleware');
 
     constructor(

--- a/src/dataloader/middleware.ts
+++ b/src/dataloader/middleware.ts
@@ -4,7 +4,7 @@ import Debug from 'debug';
 import { Request, Response } from 'express';
 import { v1 as uuid } from 'uuid';
 
-import { DEBUG, LOADER_SESSION_NAME } from '../constants';
+import { DATA_LOADER_NAMESPACE, DEBUG } from '../constants';
 import { InjectManager } from '../decorators';
 import { MongoManager } from '../manager';
 import { DataloaderService } from './service';
@@ -19,11 +19,11 @@ export class DataLoaderMiddleware implements NestMiddleware {
     ) {}
 
     use(req: Request, res: Response, next: Function) {
-        const namespace = createNamespace(LOADER_SESSION_NAME);
+        const namespace = createNamespace(DATA_LOADER_NAMESPACE);
         const loaderId = uuid();
-        req[LOADER_SESSION_NAME + '_uuid'] = loaderId;
+        req[DATA_LOADER_NAMESPACE + '_uuid'] = loaderId;
         namespace.run(() => {
-            this.log('Running namespace %s', LOADER_SESSION_NAME);
+            this.log('Running namespace %s', DATA_LOADER_NAMESPACE);
             for (const [id, model] of this.em.getModels().entries()) {
                 const loader = this.dataloaderService.create(
                     model,

--- a/src/dataloader/service.ts
+++ b/src/dataloader/service.ts
@@ -1,9 +1,9 @@
 import { ClassConstructor } from 'class-transformer';
 import { getNamespace } from 'cls-hooked';
 import Debug from 'debug';
-import { Cursor, ObjectId } from 'mongodb';
+import { ClientSession, Cursor, ObjectId } from 'mongodb';
 
-import { DEBUG, LOADER_SESSION_NAME } from '../constants';
+import { DEBUG, LOADER_SESSION_NAME, MONGO_SESSION_KEY } from '../constants';
 import { EntityInterface } from '../interfaces/entity';
 import { MongoManager } from '../manager';
 import { MongoDataloader } from './data';
@@ -34,6 +34,26 @@ export class DataloaderService {
             this.log('Unable to find dataloader %s in session', id);
         }
         return loader;
+    }
+
+    getMongoSession(): ClientSession | undefined {
+        const session = this.getSession();
+        return session?.get?.(MONGO_SESSION_KEY);
+    }
+
+    setMongoSession(mongoClientSession: ClientSession): void {
+        this.log(
+            'Registering mongo session on namespace %s',
+            LOADER_SESSION_NAME
+        );
+
+        const session = this.getSession();
+        session?.set?.(MONGO_SESSION_KEY, mongoClientSession);
+    }
+
+    clearMongoSession(): void {
+        const session = this.getSession();
+        session?.set?.(MONGO_SESSION_KEY, undefined);
     }
 
     create<Model extends EntityInterface>(

--- a/src/dataloader/service.ts
+++ b/src/dataloader/service.ts
@@ -1,9 +1,9 @@
 import { ClassConstructor } from 'class-transformer';
 import { getNamespace } from 'cls-hooked';
 import Debug from 'debug';
-import { ClientSession, Cursor, ObjectId } from 'mongodb';
+import { Cursor, ObjectId } from 'mongodb';
 
-import { DEBUG, LOADER_SESSION_NAME, MONGO_SESSION_KEY } from '../constants';
+import { DATA_LOADER_NAMESPACE, DEBUG } from '../constants';
 import { EntityInterface } from '../interfaces/entity';
 import { MongoManager } from '../manager';
 import { MongoDataloader } from './data';
@@ -14,7 +14,7 @@ export class DataloaderService {
     protected readonly loaders: Map<string, MongoDataloader<any>> = new Map();
 
     getSession() {
-        return getNamespace(LOADER_SESSION_NAME);
+        return getNamespace(DATA_LOADER_NAMESPACE);
     }
 
     get<Model extends EntityInterface>(
@@ -26,7 +26,7 @@ export class DataloaderService {
         this.log('Retrieving dataloader %s', id);
         const session = this.getSession();
         if (session === undefined) {
-            this.log('Namespace %s does not exist', LOADER_SESSION_NAME);
+            this.log('Namespace %s does not exist', DATA_LOADER_NAMESPACE);
             return;
         }
         const loader = session.get(id);
@@ -34,26 +34,6 @@ export class DataloaderService {
             this.log('Unable to find dataloader %s in session', id);
         }
         return loader;
-    }
-
-    getMongoSession(): ClientSession | undefined {
-        const session = this.getSession();
-        return session?.get?.(MONGO_SESSION_KEY);
-    }
-
-    setMongoSession(mongoClientSession: ClientSession): void {
-        this.log(
-            'Registering mongo session on namespace %s',
-            LOADER_SESSION_NAME
-        );
-
-        const session = this.getSession();
-        session?.set?.(MONGO_SESSION_KEY, mongoClientSession);
-    }
-
-    clearMongoSession(): void {
-        const session = this.getSession();
-        session?.set?.(MONGO_SESSION_KEY, undefined);
     }
 
     create<Model extends EntityInterface>(

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -1,6 +1,5 @@
 import { Type } from 'class-transformer';
-import { Allow, IsDate, IsOptional } from 'class-validator';
-import { ClientSession } from 'mongodb';
+import { IsDate, IsOptional } from 'class-validator';
 
 import { TypeObjectId } from './decorators';
 import { ObjectId } from './helpers';
@@ -22,7 +21,4 @@ export abstract class Entity implements EntityInterface {
     @IsDate()
     @IsOptional()
     updatedAt?: Date;
-
-    @Allow()
-    __session?: ClientSession;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ export * from './classes/paginated';
 export * from './constants';
 export * from './dataloader/data';
 export * from './dataloader/service';
+export * from './session/middleware';
+export * from './session/service';
 export * from './decorators';
 export * from './entity';
 export * from './entity.service';

--- a/src/interfaces/entity.ts
+++ b/src/interfaces/entity.ts
@@ -1,5 +1,3 @@
-import { ClientSession } from 'mongodb';
-
 import { HistoryActions } from '../classes/history';
 import { ObjectId } from '../helpers';
 import { ISerializable } from '../serializer';
@@ -9,5 +7,4 @@ export interface EntityInterface extends ISerializable {
     createdAt: Date;
     updatedAt?: Date;
     history?: HistoryActions;
-    __session?: ClientSession;
 }

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -90,6 +90,18 @@ export class MongoManager {
         return this.dataloaderService.get<Model>(id);
     }
 
+    getMongoSession() {
+        return this.dataloaderService.getMongoSession();
+    }
+
+    setMongoSession(mongoSession: ClientSession): void {
+        this.dataloaderService.setMongoSession(mongoSession);
+    }
+
+    clearMongoSession(): void {
+        this.dataloaderService.clearMongoSession();
+    }
+
     getCollectionName<Model extends EntityInterface>(
         nameOrInstance: Model | ClassConstructor<Model>
     ): string {

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -29,6 +29,7 @@ import {
     RelationshipMetadata,
 } from './relationship/metadata';
 import { MongoRepository } from './repository';
+import { SessionLoaderService } from './session/service';
 import { fromPlain, merge } from './transformers/utils';
 
 export class MongoManager {
@@ -40,6 +41,7 @@ export class MongoManager {
         @InjectMongoClient()
         protected readonly client: MongoClient,
         protected readonly dataloaderService: DataloaderService,
+        protected readonly sessionLoaderService: SessionLoaderService,
         protected readonly exceptionFactory: ExceptionFactory
     ) {}
 
@@ -88,20 +90,24 @@ export class MongoManager {
         return this.dataloaderService;
     }
 
+    getSessionLoaderService() {
+        return this.sessionLoaderService;
+    }
+
     getDataloader<Model extends EntityInterface>(id: string) {
         return this.dataloaderService.get<Model>(id);
     }
 
     getMongoSession() {
-        return this.dataloaderService.getMongoSession();
+        return this.sessionLoaderService.getMongoSession();
     }
 
     setMongoSession(mongoSession: ClientSession): void {
-        this.dataloaderService.setMongoSession(mongoSession);
+        this.sessionLoaderService.setMongoSession(mongoSession);
     }
 
     clearMongoSession(): void {
-        this.dataloaderService.clearMongoSession();
+        this.sessionLoaderService.clearMongoSession();
     }
 
     getCollectionName<Model extends EntityInterface>(

--- a/src/module.core.ts
+++ b/src/module.core.ts
@@ -104,10 +104,14 @@ export class MongoCoreModule implements OnModuleDestroy, OnModuleInit {
                     config.exceptionFactory
                 );
 
-                const c = getFromContainer(IsValidRelationshipConstraint);
-                c.setEm(em);
-                const c2 = getFromContainer(IsUniqueConstraint);
-                c2.setEm(em);
+                const isValidRelationship = getFromContainer(
+                    IsValidRelationshipConstraint
+                );
+                isValidRelationship.setEm(em);
+                isValidRelationship.setDataloaderService(dataloaderService);
+
+                const isUnique = getFromContainer(IsUniqueConstraint);
+                isUnique.setEm(em);
 
                 return em;
             },

--- a/src/relationship/constraint.ts
+++ b/src/relationship/constraint.ts
@@ -1,7 +1,6 @@
 import { ValidatorConstraint, ValidatorConstraintInterface } from 'class-validator';
 import { first, isEmpty } from 'lodash';
 
-import { DataloaderService } from '../dataloader/service';
 import { ObjectId } from '../helpers';
 import { EntityInterface } from '../interfaces/entity';
 import { MongoManager } from '../manager';
@@ -12,8 +11,6 @@ import { getRelationshipMetadata, RelationshipMetadata } from './metadata';
 export class IsValidRelationshipConstraint
     implements ValidatorConstraintInterface {
     private em: MongoManager;
-    private dataloaderService: DataloaderService;
-
     private message: string;
 
     defaultMessage?(args?: IsValidRelationshipValidationArguments): string {
@@ -25,8 +22,8 @@ export class IsValidRelationshipConstraint
         args: IsValidRelationshipValidationArguments
     ) {
         const entity = args.object as EntityInterface;
-
-        const session = this.dataloaderService.getMongoSession();
+        const sessionLoaderService = this.em.getSessionLoaderService();
+        const session = sessionLoaderService.getMongoSession();
 
         try {
             const relationMetadata: RelationshipMetadata<any> = getRelationshipMetadata(
@@ -116,13 +113,6 @@ export class IsValidRelationshipConstraint
 
     setEm(em: MongoManager): IsValidRelationshipConstraint {
         this.em = em;
-        return this;
-    }
-
-    setDataloaderService(
-        service: DataloaderService
-    ): IsValidRelationshipConstraint {
-        this.dataloaderService = service;
         return this;
     }
 }

--- a/src/session/middleware.ts
+++ b/src/session/middleware.ts
@@ -1,0 +1,24 @@
+import { Inject, Injectable, NestMiddleware } from '@nestjs/common';
+import { createNamespace } from 'cls-hooked';
+import Debug from 'debug';
+import { Request, Response } from 'express';
+
+import { DEBUG, SESSION_LOADER_NAMESPACE } from '../constants';
+import { InjectManager } from '../decorators';
+import { MongoManager } from '../manager';
+import { SessionLoaderService } from './service';
+
+@Injectable()
+export class SessionLoaderMiddleware implements NestMiddleware {
+    protected log = Debug(`${DEBUG}:SessionLoaderMiddleware`);
+    @InjectManager() protected readonly em: MongoManager;
+    @Inject(SessionLoaderService)
+    protected readonly service: SessionLoaderService;
+
+    use(_: Request, __: Response, next: Function) {
+        createNamespace(SESSION_LOADER_NAMESPACE).run(() => {
+            this.log('Running namespace %s', SESSION_LOADER_NAMESPACE);
+            next();
+        });
+    }
+}

--- a/src/session/orchestrator.ts
+++ b/src/session/orchestrator.ts
@@ -1,0 +1,37 @@
+import { Debugger } from 'debug';
+
+/**
+ * Transactions in sessions need to be sequential
+ * Utility class to allow wrapping promises sequentially when used
+ * in a Promise.all context.
+ */
+export class TransactionsOrchestrator {
+    protected readonly jobs: Array<Promise<any>> = [];
+    protected current: number = 0;
+
+    constructor(protected readonly log: Debugger) {}
+
+    async addJob<F extends () => Promise<any>>(
+        jobFunc: F
+    ): Promise<ReturnType<F>> {
+        const current = this.current;
+        this.log('Registering job %s on orchestrator', current);
+
+        this.jobs.push(
+            new Promise((resolve, reject) => {
+                const prevJob = this.jobs?.[current - 1] ?? Promise.resolve();
+                prevJob
+                    .then(() => {
+                        this.log('Executing job %s on orchestrator', current);
+                        return resolve(jobFunc());
+                    })
+                    .catch((e) => reject(e));
+            })
+        );
+
+        const result = this.jobs[current];
+        this.current += 1;
+
+        return await result;
+    }
+}

--- a/src/session/service.ts
+++ b/src/session/service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common';
+import { getNamespace } from 'cls-hooked';
+import Debug from 'debug';
+import { ClientSession } from 'mongodb';
+
+import { DEBUG, MONGO_SESSION_KEY, SESSION_LOADER_NAMESPACE } from '../constants';
+
+@Injectable()
+export class SessionLoaderService {
+    protected log = Debug(`${DEBUG}:SessionLoaderService`);
+
+    getSession() {
+        return getNamespace(SESSION_LOADER_NAMESPACE);
+    }
+
+    getMongoSession(): ClientSession | undefined {
+        const session = this.getSession();
+        return session?.get?.(MONGO_SESSION_KEY);
+    }
+
+    setMongoSession(mongoClientSession: ClientSession): void {
+        this.log(
+            'Registering mongo session on namespace %s',
+            SESSION_LOADER_NAMESPACE
+        );
+
+        const session = this.getSession();
+        session?.set?.(MONGO_SESSION_KEY, mongoClientSession);
+    }
+
+    clearMongoSession(): void {
+        this.log(
+            'Clearing mongo session on namespace %s',
+            SESSION_LOADER_NAMESPACE
+        );
+        const session = this.getSession();
+        session?.set?.(MONGO_SESSION_KEY, undefined);
+    }
+}

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -1,0 +1,10 @@
+import { ClientSession } from 'mongodb';
+
+import { TransactionsOrchestrator } from './orchestrator';
+
+export type ClientSessionContext =
+    | {
+          session: ClientSession;
+          orchestrator: TransactionsOrchestrator;
+      }
+    | undefined;

--- a/src/session/utils.ts
+++ b/src/session/utils.ts
@@ -1,0 +1,19 @@
+import { ClientSessionContext } from './types';
+
+export const ensureSequentialTransaction = async <F extends () => Promise<any>>(
+    ctx: ClientSessionContext,
+    jobFn: F
+): Promise<ReturnType<F>> => {
+    /**
+     * class-validator internally uses Promise.all to resolve awaiting validation promises
+     * https://github.com/typestack/class-validator/blob/615931e2903cbd680bd8fe2256e8d37dd20aeb37/src/validation/Validator.ts#L109
+     *
+     * When a session has been set on the current context, we need a way to maintain a sequential approach
+     * in the order of transactions committed to the session in order to avoid TransactionErrors that could
+     * occur when parallelizing promises via Promise.all.
+     *
+     * Using the ClientSessionContext::orchestrator allows us to force sequential promise application
+     */
+    if (ctx === undefined) return await jobFn();
+    return await ctx.orchestrator.addJob(jobFn);
+};

--- a/src/test/module/controller.ts
+++ b/src/test/module/controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, Req } from '@nestjs/common';
 import { Request } from 'express';
 
-import { LOADER_SESSION_NAME } from '../../constants';
+import { DATA_LOADER_NAMESPACE } from '../../constants';
 import { InjectManager } from '../../decorators';
 import { ObjectId } from '../../helpers';
 import { MongoManager } from '../../manager';
@@ -25,7 +25,7 @@ export class TestController {
         return {
             item,
             uuid: loader.uuid,
-            reqUuid: request[LOADER_SESSION_NAME + '_uuid']
+            reqUuid: request[DATA_LOADER_NAMESPACE + '_uuid']
         };
     }
 }

--- a/src/test/module/index.ts
+++ b/src/test/module/index.ts
@@ -1,6 +1,6 @@
 import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 
-import { DataLooaderMiddleware } from '../../dataloader/middleware';
+import { DataLoaderMiddleware } from '../../dataloader/middleware';
 import { InjectRepository } from '../../decorators';
 import { MongoModule } from '../../module';
 import { MongoRepository } from '../../repository';
@@ -50,6 +50,6 @@ export class MongoDbModuleTest implements NestModule {
     ) {}
 
     configure(consumer: MiddlewareConsumer) {
-        consumer.apply(DataLooaderMiddleware).forRoutes('test');
+        consumer.apply(DataLoaderMiddleware).forRoutes('test');
     }
 }


### PR DESCRIPTION
- no need to pass clientSession object around when using *MongoManager* API (although still possible) with save, find, findOne, getRelationship etc..
- ensure validators trigger sequentially when in _"session-mode"_
-  new API to tell the manager we're currently in _"session-mode"_, ie : 
```javascript
const em = this.repository.getEm();
const session = em.getClient().startSession();
try {
    await session.withTransaction(
        async () => {
            em.setMongoSession(session);
            /* now all calls to save, find, findOne etc.. do not need to forward the session object + constraints will use the session */
        }, {
            readPreference: 'primary',
            readConcern: {
                level: 'local'
            },
            writeConcern: {
                w: 'majority'
            }
        }
    );
} finally {
    em.clearMongoSession(); /* optional but necessary if we're continuing operations after the session ends */
    session.endSession();
}
```
or using helper : 
```javascript
await this.repository.getEm().startSessionWithTransaction(async (session) => {
            /* mongo transactions */
        }, {
            useContext: true,
            transactionOptions: {
                readPreference: 'primary',
                readConcern: {
                    level: 'local'
                },
                writeConcern: {
                    w: 'majority'
                }
            });
```
- unit tests with example