### PR TITLE
[FEAT] Dynamic Relationship : accept string return types

### DIFF
--- a/src/relationship/interfaces.ts
+++ b/src/relationship/interfaces.ts
@@ -28,7 +28,7 @@ export interface RelationshipCascade<Child extends EntityInterface = any> {
  */
 export type RelationshipTypeDescriptor<Relationship extends EntityInterface> = (
     obj?: any
-) => ClassConstructor<Relationship> | false;
+) => ClassConstructor<Relationship> | string | false;
 
 /**
  * Define a list of possible values (as string) for a property used to defined a dynamic type

--- a/test/relationship/cascade/entity.dynamic.relationship.ts
+++ b/test/relationship/cascade/entity.dynamic.relationship.ts
@@ -34,7 +34,7 @@ const DynamicRelationshipDecorator = () => {
             if (obj.parentType === DynamicRelationshipType.EntityParentDynamicRelationship1) {
                 return ParentDynamicRelationship1;
             } else if (obj.parentType === DynamicRelationshipType.EntityParentDynamicRelationship2) {
-                return ParentDynamicRelationship2;
+                return 'ParentDynamicRelationship2';
             }
             return false;
         }


### PR DESCRIPTION
Support `String` return type in `RelationshipTypeDescriptor`

ie : 
```typescript
class ChildModel extends Entity {
  @Relation((obj) => obj.condition ? 'ParentModel_1' : 'ParentModel_2')
  refId: ObjectId
}
```

Useful if ParentModel_1 & ParentModel_2 cannot be imported from ChildModel because of circular references
